### PR TITLE
Use HAI text favicon

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,12 +3,12 @@ permalink: pretty
 title: 'HAI Manifesto'
 
 logo:
-  mobile: "images/logo/logo-mobile.svg"
+  mobile: "images/logo/hai-manifesto-mobile.svg"
   mobile_height: "32px"
   mobile_width: "32px"
-  desktop: "images/logo/logo.svg"
+  desktop: "images/logo/hai-manifesto.svg"
   desktop_height: "32px"
-  desktop_width: "120px"
+  desktop_width: "240px"
 
 home: 
   limit_services: 6

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8">
   <title>{% if page.title %}{{page.title}}{% else %}{{ site.title | escape }}{% endif %}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link rel="icon" type="image/png" href="{{ '/images/favicon-32x32.svg' | relative_url }}">
+  <link rel="icon" type="image/svg+xml" href="{{ '/images/favicon.svg' | relative_url }}">
   <!-- Google Fonts CDN -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/images/favicon.svg
+++ b/images/favicon.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#E5261F"/>
+  <text x="4" y="23" font-family="Arial, Helvetica, sans-serif" font-size="18" fill="white">HAI</text>
+</svg>

--- a/images/logo/hai-manifesto-mobile.svg
+++ b/images/logo/hai-manifesto-mobile.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="white" />
+  <text x="8" y="44" font-family="Arial, Helvetica, sans-serif" font-size="36" fill="#E5261F">HAI</text>
+</svg>

--- a/images/logo/hai-manifesto.svg
+++ b/images/logo/hai-manifesto.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="480" height="64" viewBox="0 0 480 64">
+  <rect width="480" height="64" fill="white" />
+  <text x="10" y="42" font-family="Arial, Helvetica, sans-serif" font-size="40" fill="#E5261F">HAI Manifesto</text>
+</svg>


### PR DESCRIPTION
## Summary
- update favicon to show `HAI` text so the abbreviation is visible in the browser tab

## Testing
- `bundle install --path vendor/bundle` *(fails: Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: command not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6883564d7df883258c81ce17ed065403