### PR TITLE
Replace placeholder text in footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,11 +3,7 @@
     <div class="row">
       <div class="col-12">
         <div class="footer-inner">
-          <h2 class="footer-title">
-            Concept: HAI-0<br>
-            Text: HAI-3<br>
-            Website: HAI-5
-          </h2>
+          <h2 class="footer-title">The HAI Manifesto</h2>
           <ul>
             {% assign footermenu = site.data.menus.footer | sort: 'weight'  %}
             {% for item in footermenu %}


### PR DESCRIPTION
## Summary
- restore the manifesto text in `_includes/footer.html`
- restore the same text in `_data/seo.yml`

## Testing
- `bundle install` *(fails: 403 Forbidden)*
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688389e7332c8325819c5992a2bd9105