### PR TITLE
Rename EN menu link to Manifesto

### DIFF
--- a/_data/menus.yml
+++ b/_data/menus.yml
@@ -1,9 +1,9 @@
 main:
-  - name: "EN"
+  - name: "Manifesto"
     url: "/"
     weight: 1
 
 footer:
-  - name: "EN"
+  - name: "Manifesto"
     url: "/"
     weight: 1


### PR DESCRIPTION
## Summary
- rename menu links from `EN` to `Manifesto` in header and footer

## Testing
- `bundle install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6884a5a62fc88325961a6ecc63aea0d5