### PR TITLE
Implement Saffron Oxford palette

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,6 +13,7 @@
   <!-- Self host font -->
   <!-- <link rel="preload" href="{{ '/assets/fonts/playfair-display.woff2' | relative_url }}" as="font" type="font/woff2" crossorigin> -->
   <link href="{{ '/assets/css/style.css' | relative_url }}" rel="stylesheet">
+  <link rel="stylesheet" href="{{ '/assets/css/colors.css' | relative_url }}">
   
   {% if page.description %}<meta name="description" content="{{ page.description }}" />{% endif %}
   {% if page.meta_title %}<meta property="og:title" content="{{ page.meta_title }}"/>{% else %}<meta property="og:title" content="{{ page.title }}"/>{% endif %}

--- a/_sass/_colors.scss
+++ b/_sass/_colors.scss
@@ -1,0 +1,41 @@
+$brand-primary: #0B2545;
+$brand-accent:  #FFC300;
+$brand-accent-600: #E6AF00;
+$brand-accent-300: #FFD84D;
+
+$bg:       #FFFFFF;
+$surface:  #F8FAFC;
+$elevated: #EEF2F7;
+$border:   #E5E7EB;
+
+$text:        #0F172A;
+$text-muted:  #475569;
+$text-inverse:#FFFFFF;
+
+$link:       #0B2545;
+$link-hover: #15395F;
+
+$success: #1EA972;
+$warning: #B45309;
+$error:   #C1272D;
+$info:    #2563EB;
+
+/* Dark equivalents */
+$bg-dark:       #0B1120;
+$surface-dark:  #111827;
+$elevated-dark: #1F2937;
+$border-dark:   #334155;
+
+$text-dark:       #F8FAFC;
+$text-muted-dark: #94A3B8;
+
+$link-dark:       #93C5FD;
+$link-hover-dark: #BFDBFE;
+
+$brand-primary-dark: #93C5FD;
+$brand-accent-dark:  #FFD54A;
+
+$success-dark: #34D399;
+$warning-dark: #F59E0B;
+$error-dark:   #F87171;
+$info-dark:    #60A5FA;

--- a/_sass/components/_buttons.scss
+++ b/_sass/components/_buttons.scss
@@ -5,19 +5,19 @@
   line-height: 40px;
   padding: 0 14px;
   //box-shadow: 0 4px 6px rgba(50, 50, 93, 0.11), 0 1px 3px rgba(0, 0, 0, 0.08);
-  background: $primary;
+  background: var(--brand-primary);
   border-radius: 4px;
   font-size: 14px;
   font-weight: normal;
   text-transform: uppercase;
   letter-spacing: 0.025em;
-  color: #ffffff;
+  color: var(--text-inverse);
   text-decoration: none;
   -webkit-transition: all 0.15s ease;
   transition: all 0.15s ease;
   &:hover {
-    color: #ffffff;
-    background-color: lighten($primary, 10%);
+    color: var(--text-inverse);
+    background-color: var(--link-hover);
     transform: translateY(-1px);
     //box-shadow: 0 7px 14px rgba(50, 50, 93, 0.1), 0 3px 6px rgba(0, 0, 0, 0.08);
     text-decoration: none;

--- a/_sass/components/_call.scss
+++ b/_sass/components/_call.scss
@@ -1,7 +1,7 @@
 .call {
   position: relative;
   overflow: hidden;
-  background-color: $white-offset;
+  background-color: var(--surface);
   border-radius: 4px;
   // box-shadow: 0 15px 35px rgba(50, 50, 93, 0.1), 0 5px 15px rgba(0, 0, 0, 0.07);
   width: 100%;
@@ -24,7 +24,7 @@
   .call-box-bottom {
     flex: auto;
     padding: 20px;
-    border-top: 1px solid darken($white-offset, 5%);
+    border-top: 1px solid var(--border);
     @include media-breakpoint-up(sm) {
       flex: 0 0 auto;
       border: none;
@@ -39,14 +39,14 @@
   }
   .call-email {
     a {
-      color: $black;
+      color: var(--text);
     }
   }
   strong {
     font-weight: bold;
   }
   svg {
-    fill: lighten($secondary, 40%);
+    fill: var(--brand-accent-300);
     position: absolute;
     bottom: -9px;
     right: 0;

--- a/_sass/components/_feature.scss
+++ b/_sass/components/_feature.scss
@@ -3,7 +3,7 @@
   border: 1px solid $white-offset;
   border-radius: 3px;
   padding: 20px;
-  background-color: #ffffff;
+  background-color: var(--surface);
   display: flex;
   align-items: center;
   flex-direction: column;

--- a/_sass/components/_footer.scss
+++ b/_sass/components/_footer.scss
@@ -1,5 +1,6 @@
 .footer {
-  background: $footer-background-color;
+  background: var(--elevated);
+  border-top: 1px solid var(--border);
   padding-top: 15px;
   padding-bottom: 15px;
   .footer-inner {
@@ -14,7 +15,7 @@
     }
   }
   .footer-title {
-    color: #ffffff;
+    color: var(--text);
     font-size: 1.3rem;
     font-family: $font-family-heading;
     font-weight: bold;
@@ -28,10 +29,10 @@
     margin: 0;
     padding: 0;
     li {
-      color: $footer-text-color;
+      color: var(--text-muted);
       font-size: 1rem;
       a {
-        color: $footer-text-color;
+        color: var(--text-muted);
         text-decoration: none;
         padding: 12px 14px 12px 0;
         display: block;

--- a/_sass/components/_header.scss
+++ b/_sass/components/_header.scss
@@ -1,11 +1,11 @@
 .header {
-  color: $primary;
-  background-color: #ffffff;
+  color: var(--brand-primary);
+  background-color: var(--bg);
   display: flex;
   justify-content: space-between;
   align-items: center;
   // box-shadow: 0 1px 15px rgba(50, 50, 93, 0.2);
-  border-bottom: 1px solid $white-offset;
+  border-bottom: 1px solid var(--border);
   padding: 10px 0px;
   .container {
     display: flex;

--- a/_sass/components/_intro.scss
+++ b/_sass/components/_intro.scss
@@ -10,7 +10,7 @@
     padding-bottom: 140px;
   }
   h1 {
-    color: $black;
+    color: var(--text);
     font-size: 42px;
     font-weight: bold;
     line-height: 1.2;
@@ -27,14 +27,14 @@
     font-size: 1.2rem;
     line-height: 1.4;
     margin-bottom: 30px;
-    color: $black;
+    color: var(--text);
     font-family: $font-family-base;
   }
   p {
     font-size: 1.2rem;
     font-weight: light;
     line-height: 1.5;
-    color: $steel;
+    color: var(--text-muted);
     @include media-breakpoint-up(md) {
       width: 80%;
     }

--- a/_sass/components/_main-menu-mobile.scss
+++ b/_sass/components/_main-menu-mobile.scss
@@ -1,6 +1,6 @@
 .main-menu-mobile {
   position: fixed;
-  background: $primary;
+  background: var(--brand-primary);
   top: 0;
   left: 0;
   width: 100%;
@@ -54,7 +54,7 @@
       a {
         display: block;
         position: relative;
-        color: #ffffff;
+        color: var(--text-inverse);
         text-decoration: none;
         overflow: hidden;
         &:hover {

--- a/_sass/components/_main-menu.scss
+++ b/_sass/components/_main-menu.scss
@@ -15,7 +15,7 @@
         display: inline-block;
         font-weight: normal;
         text-decoration: none;
-        color: $primary;
+        color: var(--brand-primary);
         &:hover {
           text-decoration: underline;
         }

--- a/_sass/components/_strip.scss
+++ b/_sass/components/_strip.scss
@@ -1,12 +1,12 @@
 .strip {
-  background: white;
+  background: var(--bg);
   background-repeat: no-repeat;
 }
 .strip-white {
-  background-color: white;
+  background-color: var(--bg);
 }
 .strip-grey {
-  background-color: $white-offset;
+  background-color: var(--surface);
 }
 .strip-diagonal {
   transform: skewY(5deg);
@@ -23,10 +23,10 @@
   background-image: linear-gradient(to bottom, $primary, $secondary);
 }
 .strip-primary {
-  background-color: $primary;
+  background-color: var(--brand-primary);
 }
 .strip-secondary {
-  background-color: $secondary;
+  background-color: var(--brand-accent);
 }
 
 .strip-diagonal-right {

--- a/_sass/components/_title.scss
+++ b/_sass/components/_title.scss
@@ -1,5 +1,5 @@
 .title {
-  color: $black;
+  color: var(--text);
   font-size: 48px;
   line-height: 1.2;
   @include media-breakpoint-up(lg) {

--- a/_sass/pages/_page-service.scss
+++ b/_sass/pages/_page-service.scss
@@ -6,7 +6,7 @@
         line-height: 1.4;
         margin-bottom: 40px;
         font-weight: regular;
-        color: rgb(104, 104, 104);
+        color: var(--text-muted);
       }
     }
   }

--- a/_sass/pages/_page-teams.scss
+++ b/_sass/pages/_page-teams.scss
@@ -21,7 +21,7 @@
         font-weight: normal;
       }
       p {
-        color: $black;
+        color: var(--text);
         text-transform: uppercase;
         margin: 0;
         font-size: 12px;
@@ -35,7 +35,7 @@
   }
 
   .team-summary-large {
-    background-color: $white-offset;
+    background-color: var(--surface);
     padding: 30px;
     border-radius: 3px;
     .team-image {

--- a/assets/css/colors.css
+++ b/assets/css/colors.css
@@ -1,0 +1,58 @@
+/* Palette A — Saffron · Oxford (light + dark) */
+
+/* Light theme */
+:root {
+  --brand-primary: #0B2545; /* Oxford Blue */
+  --brand-accent:  #FFC300; /* Saffron */
+  --brand-accent-600: #E6AF00;
+  --brand-accent-300: #FFD84D;
+
+  --bg:        #FFFFFF;
+  --surface:   #F8FAFC;
+  --elevated:  #EEF2F7;
+  --border:    #E5E7EB;
+
+  --text:        #0F172A;
+  --text-muted:  #475569;
+  --text-inverse:#FFFFFF;
+
+  --link:       #0B2545;
+  --link-hover: #15395F;
+  --selection:  #FFC30033; /* 20% saffron */
+
+  --success: #1EA972;
+  --warning: #B45309;
+  --error:   #C1272D;
+  --info:    #2563EB;
+}
+
+/* Dark theme */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg:        #0B1120;
+    --surface:   #111827;
+    --elevated:  #1F2937;
+    --border:    #334155;
+
+    --text:       #F8FAFC;
+    --text-muted: #94A3B8;
+
+    --link:       #93C5FD;   /* lifted for contrast */
+    --link-hover: #BFDBFE;
+
+    --brand-primary: #93C5FD; /* Oxford lifted for dark */
+    --brand-accent:  #FFD54A; /* Saffron lifted for dark */
+    --selection:     #FFD54A33;
+
+    --success: #34D399;
+    --warning: #F59E0B;
+    --error:   #F87171;
+    --info:    #60A5FA;
+  }
+}
+
+html.theme-dark {
+  color-scheme: dark;
+  background: var(--bg);
+  color: var(--text);
+}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,19 +1,20 @@
 ---
 ---
 
-// Colors
-$primary: #e5261f;
-$primary-dark: #a01b16;
-$secondary: #f88379;
-$black: #2f2f41;
-$white: #ffffff;
-$white-offset: #fff6f8;
-$steel: #5c5a5a;
+@import "colors";
+
+// Colors mapped to CSS variables
+$primary: var(--brand-primary);
+$secondary: var(--brand-accent);
+$black: var(--text);
+$white: var(--text-inverse);
+$white-offset: var(--surface);
+$steel: var(--text-muted);
 
 // Links
-$link-color: $primary;
+$link-color: var(--link);
 $link-decoration: none;
-$link-hover-color: lighten($primary, 10%);
+$link-hover-color: var(--link-hover);
 $link-hover-decoration: underline;
 
 // Fonts
@@ -21,10 +22,10 @@ $font-family-base: Helvetica, Arial, sans-serif, -apple-system;
 $font-family-heading: "Playfair Display", serif, -apple-system;
 
 // Footer
-$footer-background-color: $primary;
-$footer-text-color: $white;
-$sub-footer-background-color: darken($primary, 10%);
-$sub-footer-text-color: $white;
+$footer-background-color: var(--brand-primary);
+$footer-text-color: var(--text-inverse);
+$sub-footer-background-color: var(--link-hover);
+$sub-footer-text-color: var(--text-inverse);
 
 // Bootstrap 5.3.2
 
@@ -116,3 +117,52 @@ body {
     line-height: 1.3;
   }
 }
+
+/* Base */
+html, body { background: var(--bg); color: var(--text); }
+::selection { background: var(--selection); }
+
+/* Headings & emphasis */
+h1, h2, h3 { color: var(--brand-primary); }
+strong, b  { color: var(--text); }
+
+/* Links */
+a { color: var(--link); text-decoration-color: color-mix(in srgb, var(--link) 60%, transparent); }
+a:hover { color: var(--link-hover); text-decoration-color: var(--link-hover); }
+
+/* Surfaces / cards / sections */
+.section, .card, .panel { background: var(--surface); color: var(--text); border: 1px solid var(--border); }
+hr { border: 0; border-top: 1px solid var(--border); }
+
+/* Code blocks */
+pre, code, .highlight { background: var(--elevated); color: var(--text); border: 1px solid var(--border); }
+
+/* Buttons */
+.button, .btn {
+  background: var(--brand-primary);
+  color: var(--text-inverse);
+  border: 1px solid var(--brand-primary);
+}
+.button:hover, .btn:hover { background: var(--link-hover); border-color: var(--link-hover); }
+
+.button--accent, .badge--accent {
+  background: var(--brand-accent);
+  color: var(--text-inverse);
+}
+
+/* Notices */
+.alert-info    { background: color-mix(in srgb, var(--info) 12%, var(--surface));    border: 1px solid color-mix(in srgb, var(--info) 28%, var(--border));    color: var(--text); }
+.alert-success { background: color-mix(in srgb, var(--success) 12%, var(--surface)); border: 1px solid color-mix(in srgb, var(--success) 28%, var(--border)); color: var(--text); }
+.alert-warning { background: color-mix(in srgb, var(--warning) 12%, var(--surface)); border: 1px solid color-mix(in srgb, var(--warning) 28%, var(--border)); color: var(--text); }
+.alert-error   { background: color-mix(in srgb, var(--error) 12%, var(--surface));   border: 1px solid color-mix(in srgb, var(--error) 28%, var(--border));   color: var(--text); }
+
+/* Footer */
+.site-footer { background: var(--elevated); color: var(--text-muted); border-top: 1px solid var(--border); }
+
+/* Dark-mode explicit class (optional toggle support) */
+html.theme-dark {
+  color-scheme: dark;
+  background: var(--bg);
+  color: var(--text);
+}
+


### PR DESCRIPTION
## Summary
- add light/dark CSS variables in `colors.css`
- mirror palette in `_colors.scss`
- update layout to load palette
- convert SCSS to use variables and add base rules

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884edffd05c832586aadb05e888faa8