### PR TITLE
Add HAI scorecard generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: generate-scorecards
+
+generate-scorecards:
+	python3 scripts/generate_hai_scorecards.py

--- a/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S0.svg
+++ b/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S0.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/0">
+  <defs>
+  <filter id="f-plate-0-1000" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.26 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="f-donut-0-1000" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.25 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+</defs>
+
+  <circle cx="100" cy="100" r="96" fill="#0F172A" opacity="0.1" filter="url(#f-plate-0-1000)"/>
+
+  <g filter="url(#f-donut-0-1000)">
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="452.39 0.00"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="0.00 452.39" stroke-dashoffset="-452.39"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#0F172A" opacity="0.1"/>
+
+  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">HAI/</text>
+  <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="37" font-weight="700" fill="#0B2545">0</text>
+</svg>

--- a/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S1.svg
+++ b/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S1.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/1">
+  <defs>
+  <filter id="f-plate-1-950" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.26 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="f-donut-1-950" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.25 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+</defs>
+
+  <circle cx="100" cy="100" r="96" fill="#0F172A" opacity="0.1" filter="url(#f-plate-1-950)"/>
+
+  <g filter="url(#f-donut-1-950)">
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="429.77 22.62"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="22.62 429.77" stroke-dashoffset="-429.77"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#0F172A" opacity="0.1"/>
+
+  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">HAI/</text>
+  <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="37" font-weight="700" fill="#0B2545">1</text>
+</svg>

--- a/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S2.svg
+++ b/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S2.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/2">
+  <defs>
+  <filter id="f-plate-2-800" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.26 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="f-donut-2-800" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.25 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+</defs>
+
+  <circle cx="100" cy="100" r="96" fill="#0F172A" opacity="0.1" filter="url(#f-plate-2-800)"/>
+
+  <g filter="url(#f-donut-2-800)">
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="361.91 90.48"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="90.48 361.91" stroke-dashoffset="-361.91"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#0F172A" opacity="0.1"/>
+
+  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">HAI/</text>
+  <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="37" font-weight="700" fill="#0B2545">2</text>
+</svg>

--- a/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S3.svg
+++ b/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S3.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/3">
+  <defs>
+  <filter id="f-plate-3-700" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.26 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="f-donut-3-700" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.25 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+</defs>
+
+  <circle cx="100" cy="100" r="96" fill="#0F172A" opacity="0.1" filter="url(#f-plate-3-700)"/>
+
+  <g filter="url(#f-donut-3-700)">
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="316.67 135.72"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="135.72 316.67" stroke-dashoffset="-316.67"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#0F172A" opacity="0.1"/>
+
+  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">HAI/</text>
+  <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="37" font-weight="700" fill="#0B2545">3</text>
+</svg>

--- a/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S4.svg
+++ b/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S4.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/4">
+  <defs>
+  <filter id="f-plate-4-600" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.26 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="f-donut-4-600" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.25 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+</defs>
+
+  <circle cx="100" cy="100" r="96" fill="#0F172A" opacity="0.1" filter="url(#f-plate-4-600)"/>
+
+  <g filter="url(#f-donut-4-600)">
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="271.43 180.96"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="180.96 271.43" stroke-dashoffset="-271.43"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#0F172A" opacity="0.1"/>
+
+  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">HAI/</text>
+  <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="37" font-weight="700" fill="#0B2545">4</text>
+</svg>

--- a/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S5.svg
+++ b/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S5.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/5">
+  <defs>
+  <filter id="f-plate-5-500" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.26 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="f-donut-5-500" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.25 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+</defs>
+
+  <circle cx="100" cy="100" r="96" fill="#0F172A" opacity="0.1" filter="url(#f-plate-5-500)"/>
+
+  <g filter="url(#f-donut-5-500)">
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="226.19 226.19"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="226.19 226.19" stroke-dashoffset="-226.19"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#0F172A" opacity="0.1"/>
+
+  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">HAI/</text>
+  <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="37" font-weight="700" fill="#0B2545">5</text>
+</svg>

--- a/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S6.svg
+++ b/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S6.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/6">
+  <defs>
+  <filter id="f-plate-6-300" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.26 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="f-donut-6-300" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.25 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+</defs>
+
+  <circle cx="100" cy="100" r="96" fill="#0F172A" opacity="0.1" filter="url(#f-plate-6-300)"/>
+
+  <g filter="url(#f-donut-6-300)">
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="135.72 316.67"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="316.67 135.72" stroke-dashoffset="-135.72"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#0F172A" opacity="0.1"/>
+
+  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">HAI/</text>
+  <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="37" font-weight="700" fill="#0B2545">6</text>
+</svg>

--- a/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S7.svg
+++ b/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S7.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/7">
+  <defs>
+  <filter id="f-plate-7-200" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.26 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="f-donut-7-200" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.25 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+</defs>
+
+  <circle cx="100" cy="100" r="96" fill="#0F172A" opacity="0.1" filter="url(#f-plate-7-200)"/>
+
+  <g filter="url(#f-donut-7-200)">
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="90.48 361.91"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="361.91 90.48" stroke-dashoffset="-90.48"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#0F172A" opacity="0.1"/>
+
+  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">HAI/</text>
+  <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="37" font-weight="700" fill="#0B2545">7</text>
+</svg>

--- a/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S8.svg
+++ b/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S8.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/8">
+  <defs>
+  <filter id="f-plate-8-100" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.26 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="f-donut-8-100" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.25 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+</defs>
+
+  <circle cx="100" cy="100" r="96" fill="#0F172A" opacity="0.1" filter="url(#f-plate-8-100)"/>
+
+  <g filter="url(#f-donut-8-100)">
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="45.24 407.15"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="407.15 45.24" stroke-dashoffset="-45.24"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#0F172A" opacity="0.1"/>
+
+  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">HAI/</text>
+  <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="37" font-weight="700" fill="#0B2545">8</text>
+</svg>

--- a/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S9.svg
+++ b/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S9.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/9">
+  <defs>
+  <filter id="f-plate-9-0" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.26 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="f-donut-9-0" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.25 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+</defs>
+
+  <circle cx="100" cy="100" r="96" fill="#0F172A" opacity="0.1" filter="url(#f-plate-9-0)"/>
+
+  <g filter="url(#f-donut-9-0)">
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="0.00 452.39"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="452.39 0.00" stroke-dashoffset="-0.00"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#0F172A" opacity="0.1"/>
+
+  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">HAI/</text>
+  <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="37" font-weight="700" fill="#0B2545">9</text>
+</svg>

--- a/assets/scorecards/light-translucent/HAI_sticker_lightPlate14_S0.svg
+++ b/assets/scorecards/light-translucent/HAI_sticker_lightPlate14_S0.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/0">
+  <defs>
+  <filter id="f-plate-0-1000" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.26 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="f-donut-0-1000" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.25 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+</defs>
+
+  <circle cx="100" cy="100" r="96" fill="#FFFFFF" opacity="0.14" filter="url(#f-plate-0-1000)"/>
+
+  <g filter="url(#f-donut-0-1000)">
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="452.39 0.00"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="0.00 452.39" stroke-dashoffset="-452.39"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#FFFFFF" opacity="0.14"/>
+
+  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">HAI/</text>
+  <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="37" font-weight="700" fill="#0B2545">0</text>
+</svg>

--- a/assets/scorecards/light-translucent/HAI_sticker_lightPlate14_S1.svg
+++ b/assets/scorecards/light-translucent/HAI_sticker_lightPlate14_S1.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/1">
+  <defs>
+  <filter id="f-plate-1-950" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.26 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="f-donut-1-950" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.25 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+</defs>
+
+  <circle cx="100" cy="100" r="96" fill="#FFFFFF" opacity="0.14" filter="url(#f-plate-1-950)"/>
+
+  <g filter="url(#f-donut-1-950)">
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="429.77 22.62"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="22.62 429.77" stroke-dashoffset="-429.77"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#FFFFFF" opacity="0.14"/>
+
+  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">HAI/</text>
+  <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="37" font-weight="700" fill="#0B2545">1</text>
+</svg>

--- a/assets/scorecards/light-translucent/HAI_sticker_lightPlate14_S2.svg
+++ b/assets/scorecards/light-translucent/HAI_sticker_lightPlate14_S2.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/2">
+  <defs>
+  <filter id="f-plate-2-800" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.26 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="f-donut-2-800" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.25 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+</defs>
+
+  <circle cx="100" cy="100" r="96" fill="#FFFFFF" opacity="0.14" filter="url(#f-plate-2-800)"/>
+
+  <g filter="url(#f-donut-2-800)">
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="361.91 90.48"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="90.48 361.91" stroke-dashoffset="-361.91"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#FFFFFF" opacity="0.14"/>
+
+  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">HAI/</text>
+  <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="37" font-weight="700" fill="#0B2545">2</text>
+</svg>

--- a/assets/scorecards/light-translucent/HAI_sticker_lightPlate14_S3.svg
+++ b/assets/scorecards/light-translucent/HAI_sticker_lightPlate14_S3.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/3">
+  <defs>
+  <filter id="f-plate-3-700" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.26 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="f-donut-3-700" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.25 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+</defs>
+
+  <circle cx="100" cy="100" r="96" fill="#FFFFFF" opacity="0.14" filter="url(#f-plate-3-700)"/>
+
+  <g filter="url(#f-donut-3-700)">
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="316.67 135.72"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="135.72 316.67" stroke-dashoffset="-316.67"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#FFFFFF" opacity="0.14"/>
+
+  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">HAI/</text>
+  <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="37" font-weight="700" fill="#0B2545">3</text>
+</svg>

--- a/assets/scorecards/light-translucent/HAI_sticker_lightPlate14_S4.svg
+++ b/assets/scorecards/light-translucent/HAI_sticker_lightPlate14_S4.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/4">
+  <defs>
+  <filter id="f-plate-4-600" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.26 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="f-donut-4-600" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.25 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+</defs>
+
+  <circle cx="100" cy="100" r="96" fill="#FFFFFF" opacity="0.14" filter="url(#f-plate-4-600)"/>
+
+  <g filter="url(#f-donut-4-600)">
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="271.43 180.96"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="180.96 271.43" stroke-dashoffset="-271.43"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#FFFFFF" opacity="0.14"/>
+
+  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">HAI/</text>
+  <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="37" font-weight="700" fill="#0B2545">4</text>
+</svg>

--- a/assets/scorecards/light-translucent/HAI_sticker_lightPlate14_S5.svg
+++ b/assets/scorecards/light-translucent/HAI_sticker_lightPlate14_S5.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/5">
+  <defs>
+  <filter id="f-plate-5-500" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.26 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="f-donut-5-500" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.25 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+</defs>
+
+  <circle cx="100" cy="100" r="96" fill="#FFFFFF" opacity="0.14" filter="url(#f-plate-5-500)"/>
+
+  <g filter="url(#f-donut-5-500)">
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="226.19 226.19"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="226.19 226.19" stroke-dashoffset="-226.19"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#FFFFFF" opacity="0.14"/>
+
+  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">HAI/</text>
+  <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="37" font-weight="700" fill="#0B2545">5</text>
+</svg>

--- a/assets/scorecards/light-translucent/HAI_sticker_lightPlate14_S6.svg
+++ b/assets/scorecards/light-translucent/HAI_sticker_lightPlate14_S6.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/6">
+  <defs>
+  <filter id="f-plate-6-300" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.26 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="f-donut-6-300" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.25 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+</defs>
+
+  <circle cx="100" cy="100" r="96" fill="#FFFFFF" opacity="0.14" filter="url(#f-plate-6-300)"/>
+
+  <g filter="url(#f-donut-6-300)">
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="135.72 316.67"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="316.67 135.72" stroke-dashoffset="-135.72"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#FFFFFF" opacity="0.14"/>
+
+  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">HAI/</text>
+  <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="37" font-weight="700" fill="#0B2545">6</text>
+</svg>

--- a/assets/scorecards/light-translucent/HAI_sticker_lightPlate14_S7.svg
+++ b/assets/scorecards/light-translucent/HAI_sticker_lightPlate14_S7.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/7">
+  <defs>
+  <filter id="f-plate-7-200" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.26 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="f-donut-7-200" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.25 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+</defs>
+
+  <circle cx="100" cy="100" r="96" fill="#FFFFFF" opacity="0.14" filter="url(#f-plate-7-200)"/>
+
+  <g filter="url(#f-donut-7-200)">
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="90.48 361.91"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="361.91 90.48" stroke-dashoffset="-90.48"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#FFFFFF" opacity="0.14"/>
+
+  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">HAI/</text>
+  <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="37" font-weight="700" fill="#0B2545">7</text>
+</svg>

--- a/assets/scorecards/light-translucent/HAI_sticker_lightPlate14_S8.svg
+++ b/assets/scorecards/light-translucent/HAI_sticker_lightPlate14_S8.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/8">
+  <defs>
+  <filter id="f-plate-8-100" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.26 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="f-donut-8-100" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.25 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+</defs>
+
+  <circle cx="100" cy="100" r="96" fill="#FFFFFF" opacity="0.14" filter="url(#f-plate-8-100)"/>
+
+  <g filter="url(#f-donut-8-100)">
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="45.24 407.15"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="407.15 45.24" stroke-dashoffset="-45.24"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#FFFFFF" opacity="0.14"/>
+
+  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">HAI/</text>
+  <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="37" font-weight="700" fill="#0B2545">8</text>
+</svg>

--- a/assets/scorecards/light-translucent/HAI_sticker_lightPlate14_S9.svg
+++ b/assets/scorecards/light-translucent/HAI_sticker_lightPlate14_S9.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/9">
+  <defs>
+  <filter id="f-plate-9-0" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.26 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="f-donut-9-0" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 0.25 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+</defs>
+
+  <circle cx="100" cy="100" r="96" fill="#FFFFFF" opacity="0.14" filter="url(#f-plate-9-0)"/>
+
+  <g filter="url(#f-donut-9-0)">
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="0.00 452.39"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="452.39 0.00" stroke-dashoffset="-0.00"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#FFFFFF" opacity="0.14"/>
+
+  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">HAI/</text>
+  <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="37" font-weight="700" fill="#0B2545">9</text>
+</svg>

--- a/assets/scorecards/print-solid-dark/HAI_sticker_print_darkSolid_S0.svg
+++ b/assets/scorecards/print-solid-dark/HAI_sticker_print_darkSolid_S0.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/0">
+  <defs></defs>
+
+  <circle cx="100" cy="100" r="96" fill="#1F2937" opacity="1.0" />
+
+  <g >
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="452.39 0.00"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="0.00 452.39" stroke-dashoffset="-452.39"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#1F2937" opacity="1.0"/>
+
+  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="18" font-weight="700" letter-spacing="0.5" fill="#FFFFFF">HAI/</text>
+  <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="37" font-weight="700" fill="#FFFFFF">0</text>
+</svg>

--- a/assets/scorecards/print-solid-dark/HAI_sticker_print_darkSolid_S1.svg
+++ b/assets/scorecards/print-solid-dark/HAI_sticker_print_darkSolid_S1.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/1">
+  <defs></defs>
+
+  <circle cx="100" cy="100" r="96" fill="#1F2937" opacity="1.0" />
+
+  <g >
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="429.77 22.62"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="22.62 429.77" stroke-dashoffset="-429.77"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#1F2937" opacity="1.0"/>
+
+  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="18" font-weight="700" letter-spacing="0.5" fill="#FFFFFF">HAI/</text>
+  <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="37" font-weight="700" fill="#FFFFFF">1</text>
+</svg>

--- a/assets/scorecards/print-solid-dark/HAI_sticker_print_darkSolid_S2.svg
+++ b/assets/scorecards/print-solid-dark/HAI_sticker_print_darkSolid_S2.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/2">
+  <defs></defs>
+
+  <circle cx="100" cy="100" r="96" fill="#1F2937" opacity="1.0" />
+
+  <g >
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="361.91 90.48"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="90.48 361.91" stroke-dashoffset="-361.91"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#1F2937" opacity="1.0"/>
+
+  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="18" font-weight="700" letter-spacing="0.5" fill="#FFFFFF">HAI/</text>
+  <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="37" font-weight="700" fill="#FFFFFF">2</text>
+</svg>

--- a/assets/scorecards/print-solid-dark/HAI_sticker_print_darkSolid_S3.svg
+++ b/assets/scorecards/print-solid-dark/HAI_sticker_print_darkSolid_S3.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/3">
+  <defs></defs>
+
+  <circle cx="100" cy="100" r="96" fill="#1F2937" opacity="1.0" />
+
+  <g >
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="316.67 135.72"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="135.72 316.67" stroke-dashoffset="-316.67"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#1F2937" opacity="1.0"/>
+
+  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="18" font-weight="700" letter-spacing="0.5" fill="#FFFFFF">HAI/</text>
+  <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="37" font-weight="700" fill="#FFFFFF">3</text>
+</svg>

--- a/assets/scorecards/print-solid-dark/HAI_sticker_print_darkSolid_S4.svg
+++ b/assets/scorecards/print-solid-dark/HAI_sticker_print_darkSolid_S4.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/4">
+  <defs></defs>
+
+  <circle cx="100" cy="100" r="96" fill="#1F2937" opacity="1.0" />
+
+  <g >
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="271.43 180.96"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="180.96 271.43" stroke-dashoffset="-271.43"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#1F2937" opacity="1.0"/>
+
+  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="18" font-weight="700" letter-spacing="0.5" fill="#FFFFFF">HAI/</text>
+  <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="37" font-weight="700" fill="#FFFFFF">4</text>
+</svg>

--- a/assets/scorecards/print-solid-dark/HAI_sticker_print_darkSolid_S5.svg
+++ b/assets/scorecards/print-solid-dark/HAI_sticker_print_darkSolid_S5.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/5">
+  <defs></defs>
+
+  <circle cx="100" cy="100" r="96" fill="#1F2937" opacity="1.0" />
+
+  <g >
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="226.19 226.19"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="226.19 226.19" stroke-dashoffset="-226.19"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#1F2937" opacity="1.0"/>
+
+  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="18" font-weight="700" letter-spacing="0.5" fill="#FFFFFF">HAI/</text>
+  <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="37" font-weight="700" fill="#FFFFFF">5</text>
+</svg>

--- a/assets/scorecards/print-solid-dark/HAI_sticker_print_darkSolid_S6.svg
+++ b/assets/scorecards/print-solid-dark/HAI_sticker_print_darkSolid_S6.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/6">
+  <defs></defs>
+
+  <circle cx="100" cy="100" r="96" fill="#1F2937" opacity="1.0" />
+
+  <g >
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="135.72 316.67"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="316.67 135.72" stroke-dashoffset="-135.72"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#1F2937" opacity="1.0"/>
+
+  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="18" font-weight="700" letter-spacing="0.5" fill="#FFFFFF">HAI/</text>
+  <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="37" font-weight="700" fill="#FFFFFF">6</text>
+</svg>

--- a/assets/scorecards/print-solid-dark/HAI_sticker_print_darkSolid_S7.svg
+++ b/assets/scorecards/print-solid-dark/HAI_sticker_print_darkSolid_S7.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/7">
+  <defs></defs>
+
+  <circle cx="100" cy="100" r="96" fill="#1F2937" opacity="1.0" />
+
+  <g >
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="90.48 361.91"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="361.91 90.48" stroke-dashoffset="-90.48"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#1F2937" opacity="1.0"/>
+
+  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="18" font-weight="700" letter-spacing="0.5" fill="#FFFFFF">HAI/</text>
+  <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="37" font-weight="700" fill="#FFFFFF">7</text>
+</svg>

--- a/assets/scorecards/print-solid-dark/HAI_sticker_print_darkSolid_S8.svg
+++ b/assets/scorecards/print-solid-dark/HAI_sticker_print_darkSolid_S8.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/8">
+  <defs></defs>
+
+  <circle cx="100" cy="100" r="96" fill="#1F2937" opacity="1.0" />
+
+  <g >
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="45.24 407.15"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="407.15 45.24" stroke-dashoffset="-45.24"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#1F2937" opacity="1.0"/>
+
+  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="18" font-weight="700" letter-spacing="0.5" fill="#FFFFFF">HAI/</text>
+  <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="37" font-weight="700" fill="#FFFFFF">8</text>
+</svg>

--- a/assets/scorecards/print-solid-dark/HAI_sticker_print_darkSolid_S9.svg
+++ b/assets/scorecards/print-solid-dark/HAI_sticker_print_darkSolid_S9.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/9">
+  <defs></defs>
+
+  <circle cx="100" cy="100" r="96" fill="#1F2937" opacity="1.0" />
+
+  <g >
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="0.00 452.39"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="452.39 0.00" stroke-dashoffset="-0.00"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#1F2937" opacity="1.0"/>
+
+  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="18" font-weight="700" letter-spacing="0.5" fill="#FFFFFF">HAI/</text>
+  <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="37" font-weight="700" fill="#FFFFFF">9</text>
+</svg>

--- a/assets/scorecards/print-solid-light/HAI_sticker_print_lightSolid_S0.svg
+++ b/assets/scorecards/print-solid-light/HAI_sticker_print_lightSolid_S0.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/0">
+  <defs></defs>
+
+  <circle cx="100" cy="100" r="96" fill="#E5E7EB" opacity="1.0" />
+
+  <g >
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="452.39 0.00"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="0.00 452.39" stroke-dashoffset="-452.39"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#E5E7EB" opacity="1.0"/>
+
+  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">HAI/</text>
+  <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="37" font-weight="700" fill="#0B2545">0</text>
+</svg>

--- a/assets/scorecards/print-solid-light/HAI_sticker_print_lightSolid_S1.svg
+++ b/assets/scorecards/print-solid-light/HAI_sticker_print_lightSolid_S1.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/1">
+  <defs></defs>
+
+  <circle cx="100" cy="100" r="96" fill="#E5E7EB" opacity="1.0" />
+
+  <g >
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="429.77 22.62"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="22.62 429.77" stroke-dashoffset="-429.77"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#E5E7EB" opacity="1.0"/>
+
+  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">HAI/</text>
+  <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="37" font-weight="700" fill="#0B2545">1</text>
+</svg>

--- a/assets/scorecards/print-solid-light/HAI_sticker_print_lightSolid_S2.svg
+++ b/assets/scorecards/print-solid-light/HAI_sticker_print_lightSolid_S2.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/2">
+  <defs></defs>
+
+  <circle cx="100" cy="100" r="96" fill="#E5E7EB" opacity="1.0" />
+
+  <g >
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="361.91 90.48"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="90.48 361.91" stroke-dashoffset="-361.91"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#E5E7EB" opacity="1.0"/>
+
+  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">HAI/</text>
+  <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="37" font-weight="700" fill="#0B2545">2</text>
+</svg>

--- a/assets/scorecards/print-solid-light/HAI_sticker_print_lightSolid_S3.svg
+++ b/assets/scorecards/print-solid-light/HAI_sticker_print_lightSolid_S3.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/3">
+  <defs></defs>
+
+  <circle cx="100" cy="100" r="96" fill="#E5E7EB" opacity="1.0" />
+
+  <g >
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="316.67 135.72"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="135.72 316.67" stroke-dashoffset="-316.67"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#E5E7EB" opacity="1.0"/>
+
+  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">HAI/</text>
+  <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="37" font-weight="700" fill="#0B2545">3</text>
+</svg>

--- a/assets/scorecards/print-solid-light/HAI_sticker_print_lightSolid_S4.svg
+++ b/assets/scorecards/print-solid-light/HAI_sticker_print_lightSolid_S4.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/4">
+  <defs></defs>
+
+  <circle cx="100" cy="100" r="96" fill="#E5E7EB" opacity="1.0" />
+
+  <g >
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="271.43 180.96"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="180.96 271.43" stroke-dashoffset="-271.43"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#E5E7EB" opacity="1.0"/>
+
+  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">HAI/</text>
+  <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="37" font-weight="700" fill="#0B2545">4</text>
+</svg>

--- a/assets/scorecards/print-solid-light/HAI_sticker_print_lightSolid_S5.svg
+++ b/assets/scorecards/print-solid-light/HAI_sticker_print_lightSolid_S5.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/5">
+  <defs></defs>
+
+  <circle cx="100" cy="100" r="96" fill="#E5E7EB" opacity="1.0" />
+
+  <g >
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="226.19 226.19"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="226.19 226.19" stroke-dashoffset="-226.19"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#E5E7EB" opacity="1.0"/>
+
+  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">HAI/</text>
+  <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="37" font-weight="700" fill="#0B2545">5</text>
+</svg>

--- a/assets/scorecards/print-solid-light/HAI_sticker_print_lightSolid_S6.svg
+++ b/assets/scorecards/print-solid-light/HAI_sticker_print_lightSolid_S6.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/6">
+  <defs></defs>
+
+  <circle cx="100" cy="100" r="96" fill="#E5E7EB" opacity="1.0" />
+
+  <g >
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="135.72 316.67"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="316.67 135.72" stroke-dashoffset="-135.72"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#E5E7EB" opacity="1.0"/>
+
+  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">HAI/</text>
+  <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="37" font-weight="700" fill="#0B2545">6</text>
+</svg>

--- a/assets/scorecards/print-solid-light/HAI_sticker_print_lightSolid_S7.svg
+++ b/assets/scorecards/print-solid-light/HAI_sticker_print_lightSolid_S7.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/7">
+  <defs></defs>
+
+  <circle cx="100" cy="100" r="96" fill="#E5E7EB" opacity="1.0" />
+
+  <g >
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="90.48 361.91"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="361.91 90.48" stroke-dashoffset="-90.48"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#E5E7EB" opacity="1.0"/>
+
+  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">HAI/</text>
+  <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="37" font-weight="700" fill="#0B2545">7</text>
+</svg>

--- a/assets/scorecards/print-solid-light/HAI_sticker_print_lightSolid_S8.svg
+++ b/assets/scorecards/print-solid-light/HAI_sticker_print_lightSolid_S8.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/8">
+  <defs></defs>
+
+  <circle cx="100" cy="100" r="96" fill="#E5E7EB" opacity="1.0" />
+
+  <g >
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="45.24 407.15"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="407.15 45.24" stroke-dashoffset="-45.24"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#E5E7EB" opacity="1.0"/>
+
+  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">HAI/</text>
+  <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="37" font-weight="700" fill="#0B2545">8</text>
+</svg>

--- a/assets/scorecards/print-solid-light/HAI_sticker_print_lightSolid_S9.svg
+++ b/assets/scorecards/print-solid-light/HAI_sticker_print_lightSolid_S9.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/9">
+  <defs></defs>
+
+  <circle cx="100" cy="100" r="96" fill="#E5E7EB" opacity="1.0" />
+
+  <g >
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="0.00 452.39"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="452.39 0.00" stroke-dashoffset="-0.00"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="46" fill="#E5E7EB" opacity="1.0"/>
+
+  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="18" font-weight="700" letter-spacing="0.5" fill="#0B2545">HAI/</text>
+  <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="37" font-weight="700" fill="#0B2545">9</text>
+</svg>

--- a/scripts/generate_hai_scorecards.py
+++ b/scripts/generate_hai_scorecards.py
@@ -1,0 +1,104 @@
+import math, os, hashlib, pathlib
+
+RADIUS = 72
+RING_WIDTH = 42
+PLATE_RADIUS = 96
+CENTER_RADIUS = 46
+
+HUMAN = "#FFC300"
+AI = "#0B2545"
+TEXT_OXFORD = "#0B2545"
+TEXT_WHITE = "#FFFFFF"
+
+FRACTIONS = {0:1.00, 1:0.95, 2:0.80, 3:0.70, 4:0.60, 5:0.50, 6:0.30, 7:0.20, 8:0.10, 9:0.00}
+
+SETS = [
+    # name, plate_fill, plate_opacity, text_color, with_filters
+    ("dark-translucent",  "#0F172A", 0.10, TEXT_OXFORD, True),
+    ("light-translucent", "#FFFFFF", 0.14, TEXT_OXFORD, True),
+    ("print-solid-light", "#E5E7EB", 1.00, TEXT_OXFORD, False),
+    ("print-solid-dark",  "#1F2937", 1.00, TEXT_WHITE,  False),
+]
+
+def filters(uid, plate_alpha=0.26, donut_alpha=0.25):
+    return f"""
+  <filter id="f-plate-{uid}" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 {plate_alpha} 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="f-donut-{uid}" filterUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+    <feOffset in="SourceAlpha" dx="0" dy="2" result="off"/>
+    <feGaussianBlur in="off" stdDeviation="2" result="blur"/>
+    <feColorMatrix in="blur" type="matrix"
+      values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0   0 0 0 {donut_alpha} 0" result="shadow"/>
+    <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+"""
+
+def svg_for(score, p, plate_fill, plate_opacity, text_color, with_filters):
+    C = 2 * math.pi * RADIUS
+    H = p * C
+    A = (1 - p) * C
+    # Round to two decimals for SVG
+    Hs, As = f"{H:.2f}", f"{A:.2f}"
+
+    uid = f"{score}-{int(p*1000)}"
+    defs = filters(uid) if with_filters else ""
+    plate_filter_attr = f'filter="url(#f-plate-{uid})"' if with_filters else ""
+    donut_filter_attr = f'filter="url(#f-donut-{uid})"' if with_filters else ""
+
+    svg = f'''<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" aria-label="HAI/{score}">
+  <defs>{defs}</defs>
+
+  <circle cx="100" cy="100" r="{PLATE_RADIUS}" fill="{plate_fill}" opacity="{plate_opacity}" {plate_filter_attr}/>
+
+  <g {donut_filter_attr}>
+    <g transform="rotate(-90 100 100)">
+      <circle cx="100" cy="100" r="{RADIUS}" fill="none"
+              stroke="{HUMAN}" stroke-width="{RING_WIDTH}" stroke-linecap="butt"
+              stroke-dasharray="{Hs} {As}"/>
+      <circle cx="100" cy="100" r="{RADIUS}" fill="none"
+              stroke="{AI}" stroke-width="{RING_WIDTH}" stroke-linecap="butt"
+              stroke-dasharray="{As} {Hs}" stroke-dashoffset="-{Hs}"/>
+    </g>
+  </g>
+
+  <circle cx="100" cy="100" r="{CENTER_RADIUS}" fill="{plate_fill}" opacity="{plate_opacity}"/>
+
+  <text x="100" y="82" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="18" font-weight="700" letter-spacing="0.5" fill="{text_color}">HAI/</text>
+  <text x="100" y="115" text-anchor="middle" font-family="Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="37" font-weight="700" fill="{text_color}">{score}</text>
+</svg>'''
+    return svg
+
+def main():
+    base = pathlib.Path("assets/scorecards")
+    (base / "dark-translucent").mkdir(parents=True, exist_ok=True)
+    (base / "light-translucent").mkdir(parents=True, exist_ok=True)
+    (base / "print-solid-light").mkdir(parents=True, exist_ok=True)
+    (base / "print-solid-dark").mkdir(parents=True, exist_ok=True)
+
+    for set_name, plate_fill, plate_opacity, text_color, with_filters in SETS:
+        outdir = base / set_name
+        for score, p in FRACTIONS.items():
+            svg = svg_for(score, p, plate_fill, plate_opacity, text_color, with_filters)
+            filename = f"HAI_sticker_{set_name.replace('-', '')}_S{score}.svg"
+            # Keep legacy-friendly names too
+            if set_name == "dark-translucent":
+                filename = f"HAI_sticker_darkPlate10_S{score}.svg"
+            elif set_name == "light-translucent":
+                filename = f"HAI_sticker_lightPlate14_S{score}.svg"
+            elif set_name == "print-solid-light":
+                filename = f"HAI_sticker_print_lightSolid_S{score}.svg"
+            elif set_name == "print-solid-dark":
+                filename = f"HAI_sticker_print_darkSolid_S{score}.svg"
+
+            (outdir / filename).write_text(svg, encoding="utf-8")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- generate HAI sticker SVGs (score 0–9) for four visual styles
- add Makefile helper to run generator
- commit generated assets

## Testing
- `python3 scripts/generate_hai_scorecards.py`


------
https://chatgpt.com/codex/tasks/task_e_6885028e89c08325bedf66822923d072