### PR TITLE
Display HAI score cards on homepage

### DIFF
--- a/index.md
+++ b/index.md
@@ -42,69 +42,89 @@ The meaning of the score is always contextual. Some situations — such as perso
 ---
 
 ### **HAI/0** - *Fully human-authored.*
+
+![HAI Score 0](/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S0.svg){: width="120" height="120" }
  
 **Human Intelligence:** Full authorship: idea, structure, writing, editing.\
 **Artificial Intelligence:** None. No digital assistance beyond basic tools like typing.  
 
 ---
 
-### **HAI/1** – *AI as proofreader.* 
+### **HAI/1** – *AI as proofreader.*
+
+![HAI Score 1](/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S1.svg){: width="120" height="120" }
 
 **Human Intelligence:**  Provides full content and structure.\
 **Artificial Intelligence:** Spelling, punctuation, minor grammar fixes. AI used only for surface-level corrections, with no effect on meaning or style. 
 
 ---
 
-### **HAI/2** – *AI as verifier.* 
+### **HAI/2** – *AI as verifier.*
+
+![HAI Score 2](/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S2.svg){: width="120" height="120" }
 
 **Human Intelligence:** Human writes everything; Generates ideas, writes and edits content.\
 **Artificial Intelligence:** AI assists only with basic clarity and logic checks. Supports human thinking without reshaping the work. Suggests clarifications, flags inconsistencies. 
 
 ---
 
-### **HAI/3** – *AI as stylist.* 
+### **HAI/3** – *AI as stylist.*
+
+![HAI Score 3](/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S3.svg){: width="120" height="120" }
 
 **Human Intelligence:** Human authorship with AI assistance on form, tone, or voice. Writes content and defines the core message.\
 **Artificial Intelligence:** Refines the form without altering substance. Rewrites passages for clarity, tone, or flow. 
 
 ---
 
-### **HAI/4** – *AI as architect.* 
+### **HAI/4** – *AI as architect.*
+
+![HAI Score 4](/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S4.svg){: width="120" height="120" }
 
 **Human Intelligence:** Human defines what to say; Provides the core idea, thesis, or message.\
 **Artificial Intelligence:** AI proposes how to say it structurally based on human intent. Builds outline, section structure, and flow. 
 
 ---
 
-### **HAI/5** – *AI as co-author.* 
+### **HAI/5** – *AI as co-author.*
+
+![HAI Score 5](/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S5.svg){: width="120" height="120" }
 
 **Human Intelligence:** Human defines the vision; Provides topic, intent, and guidance.\
 **Artificial Intelligence:** AI produces much of the initial content. Produces under human direction. Generates outline and writes first drafts. 
 
 ---
 
-### **HAI/6** – *AI as autonomous drafter.* 
+### **HAI/6** – *AI as autonomous drafter.*
+
+![HAI Score 6](/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S6.svg){: width="120" height="120" }
 
 **Human Intelligence:** Human provides only creative spark. Offers a prompt, theme, or starting idea.\
 **Artificial Intelligence:** AI creates full content from a minimal human prompt or concept. Develops full structure and detailed content. 
 
 ---
 
-### **HAI/7** – *AI as lead author.* 
+### **HAI/7** – *AI as lead author.*
+
+![HAI Score 7](/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S7.svg){: width="120" height="120" }
 
 **Human Intelligence:** Human curates or selects among AI-generated versions. Human plays a reviewing role; Sets goal, gives light feedback, selects output.\
 **Artificial Intelligence:** AI explores and evolves the draft. Produces multiple versions and refines content. 
 
 ---
 
-### **HAI/8** – *AI as sole creator.* 
+### **HAI/8** – *AI as sole creator.*
+
+![HAI Score 8](/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S8.svg){: width="120" height="120" }
 
 **Human Intelligence:** Human involvement is passive or distant. Provides only a general topic or intent to publish.\
 **Artificial Intelligence:** AI authors the work from start to finish; Invents idea, structure, content, and revisions. 
 
 ---
 
-### **HAI/9** – *Fully AI-authored.* 
+### **HAI/9** – *Fully AI-authored.*
+
+![HAI Score 9](/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S9.svg){: width="120" height="120" }
 
 **Human Intelligence:** None. Human did not contribute to ideation, structure, or selection but merely triggers or uploads the result.\
 **Artificial Intelligence:** Fully AI-generated with no human creative input. Complete authorship: concept, writing, style, and editing. 


### PR DESCRIPTION
## Summary
- add HAI score card SVGs beside each level description on index page

## Testing
- `git diff --check`

------
https://chatgpt.com/codex/tasks/task_e_688504a451a0832583da961869ba9cc4