### PR TITLE
Replace Sass vars with CSS custom properties

### DIFF
--- a/_sass/components/_content.scss
+++ b/_sass/components/_content.scss
@@ -17,7 +17,7 @@
   p {
     font-family: $font-family-base;
     line-height: 1.56;
-    color: $steel;
+    color: var(--text-muted);
   }
   h1 {
     font-family: $font-family-base;
@@ -59,11 +59,11 @@
     margin-bottom: 5px;
     line-height: 1.56;
     margin-left: 20px;
-    color: $steel;
+    color: var(--text-muted);
   }
   hr {
     border: none;
-    border-bottom: 1px solid $white-offset;
+    border-bottom: 1px solid var(--surface);
   }
   table {
     width: 100%;
@@ -73,21 +73,21 @@
     td {
       padding: 5px;
       vertical-align: top;
-      border-top: 1px solid $white-offset;
+      border-top: 1px solid var(--surface);
     }
     thead th {
       vertical-align: bottom;
-      border-bottom: 1px solid $white-offset;
+      border-bottom: 1px solid var(--surface);
       text-align: left;
       font-weight: bold;
     }
     tbody + tbody {
-      border-top: 1px solid $white-offset;
+      border-top: 1px solid var(--surface);
     }
   }
   blockquote {
     padding: 0 1em;
-    color: $steel;
-    border-left: .25em solid $secondary;
+    color: var(--text-muted);
+    border-left: .25em solid var(--brand-accent);
   }
 }

--- a/_sass/components/_hamburger.scss
+++ b/_sass/components/_hamburger.scss
@@ -12,7 +12,7 @@
   .hamburger-inner,
   .hamburger-inner::before,
   .hamburger-inner::after {
-    background: $primary;
+    background: var(--brand-primary);
   }
   .hamburger-inner::after {
     width: 18px;

--- a/_sass/components/_strip.scss
+++ b/_sass/components/_strip.scss
@@ -17,10 +17,10 @@
   }
 }
 .strip-primary-gradient {
-  background-image: linear-gradient(to right, $primary, $secondary);
+  background-image: linear-gradient(to right, var(--brand-primary), var(--brand-accent));
 }
 .strip-primary-gradient-top-bottom {
-  background-image: linear-gradient(to bottom, $primary, $secondary);
+  background-image: linear-gradient(to bottom, var(--brand-primary), var(--brand-accent));
 }
 .strip-primary {
   background-color: var(--brand-primary);

--- a/_sass/components/_type.scss
+++ b/_sass/components/_type.scss
@@ -1,6 +1,6 @@
 p {
   line-height: 26px;
-  color: $steel;
+  color: var(--text-muted);
   font-family: $font-family-base;
   margin-bottom: 20px;
 }


### PR DESCRIPTION
## Summary
- swap sass color variables for CSS custom properties in custom components
- keep gradient colours consistent with CSS variables

## Testing
- `bundle exec jekyll build` *(fails: bundler could not find `jekyll` executable)*

------
https://chatgpt.com/codex/tasks/task_e_688548497e808325b1230be5046c9bfc