### PR TITLE
Fix navi arc orientation

### DIFF
--- a/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S0.svg
+++ b/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S0.svg
@@ -22,11 +22,11 @@
   <g filter="url(#f-donut-0-1000)">
     <g transform="rotate(-90 100 100)">
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="452.39 0.00"/>
-      <circle cx="100" cy="100" r="72" fill="none"
               stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="0.00 452.39" stroke-dashoffset="-452.39"/>
+              stroke-dasharray="0.00 452.39"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="452.39 0.00" stroke-dashoffset="-0.00"/>
     </g>
   </g>
 

--- a/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S1.svg
+++ b/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S1.svg
@@ -22,11 +22,11 @@
   <g filter="url(#f-donut-1-950)">
     <g transform="rotate(-90 100 100)">
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="429.77 22.62"/>
-      <circle cx="100" cy="100" r="72" fill="none"
               stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="22.62 429.77" stroke-dashoffset="-429.77"/>
+              stroke-dasharray="22.62 429.77"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="429.77 22.62" stroke-dashoffset="-22.62"/>
     </g>
   </g>
 

--- a/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S2.svg
+++ b/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S2.svg
@@ -22,11 +22,11 @@
   <g filter="url(#f-donut-2-800)">
     <g transform="rotate(-90 100 100)">
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="361.91 90.48"/>
-      <circle cx="100" cy="100" r="72" fill="none"
               stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="90.48 361.91" stroke-dashoffset="-361.91"/>
+              stroke-dasharray="90.48 361.91"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="361.91 90.48" stroke-dashoffset="-90.48"/>
     </g>
   </g>
 

--- a/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S3.svg
+++ b/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S3.svg
@@ -22,11 +22,11 @@
   <g filter="url(#f-donut-3-700)">
     <g transform="rotate(-90 100 100)">
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="316.67 135.72"/>
-      <circle cx="100" cy="100" r="72" fill="none"
               stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="135.72 316.67" stroke-dashoffset="-316.67"/>
+              stroke-dasharray="135.72 316.67"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="316.67 135.72" stroke-dashoffset="-135.72"/>
     </g>
   </g>
 

--- a/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S4.svg
+++ b/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S4.svg
@@ -22,11 +22,11 @@
   <g filter="url(#f-donut-4-600)">
     <g transform="rotate(-90 100 100)">
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="271.43 180.96"/>
-      <circle cx="100" cy="100" r="72" fill="none"
               stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="180.96 271.43" stroke-dashoffset="-271.43"/>
+              stroke-dasharray="180.96 271.43"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="271.43 180.96" stroke-dashoffset="-180.96"/>
     </g>
   </g>
 

--- a/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S5.svg
+++ b/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S5.svg
@@ -22,10 +22,10 @@
   <g filter="url(#f-donut-5-500)">
     <g transform="rotate(-90 100 100)">
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
               stroke-dasharray="226.19 226.19"/>
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
               stroke-dasharray="226.19 226.19" stroke-dashoffset="-226.19"/>
     </g>
   </g>

--- a/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S6.svg
+++ b/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S6.svg
@@ -22,11 +22,11 @@
   <g filter="url(#f-donut-6-300)">
     <g transform="rotate(-90 100 100)">
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="135.72 316.67"/>
-      <circle cx="100" cy="100" r="72" fill="none"
               stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="316.67 135.72" stroke-dashoffset="-135.72"/>
+              stroke-dasharray="316.67 135.72"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="135.72 316.67" stroke-dashoffset="-316.67"/>
     </g>
   </g>
 

--- a/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S7.svg
+++ b/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S7.svg
@@ -22,11 +22,11 @@
   <g filter="url(#f-donut-7-200)">
     <g transform="rotate(-90 100 100)">
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="90.48 361.91"/>
-      <circle cx="100" cy="100" r="72" fill="none"
               stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="361.91 90.48" stroke-dashoffset="-90.48"/>
+              stroke-dasharray="361.91 90.48"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="90.48 361.91" stroke-dashoffset="-361.91"/>
     </g>
   </g>
 

--- a/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S8.svg
+++ b/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S8.svg
@@ -22,11 +22,11 @@
   <g filter="url(#f-donut-8-100)">
     <g transform="rotate(-90 100 100)">
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="45.24 407.15"/>
-      <circle cx="100" cy="100" r="72" fill="none"
               stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="407.15 45.24" stroke-dashoffset="-45.24"/>
+              stroke-dasharray="407.15 45.24"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="45.24 407.15" stroke-dashoffset="-407.15"/>
     </g>
   </g>
 

--- a/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S9.svg
+++ b/assets/scorecards/dark-translucent/HAI_sticker_darkPlate10_S9.svg
@@ -22,11 +22,11 @@
   <g filter="url(#f-donut-9-0)">
     <g transform="rotate(-90 100 100)">
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="0.00 452.39"/>
-      <circle cx="100" cy="100" r="72" fill="none"
               stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="452.39 0.00" stroke-dashoffset="-0.00"/>
+              stroke-dasharray="452.39 0.00"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="0.00 452.39" stroke-dashoffset="-452.39"/>
     </g>
   </g>
 

--- a/assets/scorecards/light-translucent/HAI_sticker_lightPlate14_S0.svg
+++ b/assets/scorecards/light-translucent/HAI_sticker_lightPlate14_S0.svg
@@ -22,11 +22,11 @@
   <g filter="url(#f-donut-0-1000)">
     <g transform="rotate(-90 100 100)">
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="452.39 0.00"/>
-      <circle cx="100" cy="100" r="72" fill="none"
               stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="0.00 452.39" stroke-dashoffset="-452.39"/>
+              stroke-dasharray="0.00 452.39"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="452.39 0.00" stroke-dashoffset="-0.00"/>
     </g>
   </g>
 

--- a/assets/scorecards/light-translucent/HAI_sticker_lightPlate14_S1.svg
+++ b/assets/scorecards/light-translucent/HAI_sticker_lightPlate14_S1.svg
@@ -22,11 +22,11 @@
   <g filter="url(#f-donut-1-950)">
     <g transform="rotate(-90 100 100)">
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="429.77 22.62"/>
-      <circle cx="100" cy="100" r="72" fill="none"
               stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="22.62 429.77" stroke-dashoffset="-429.77"/>
+              stroke-dasharray="22.62 429.77"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="429.77 22.62" stroke-dashoffset="-22.62"/>
     </g>
   </g>
 

--- a/assets/scorecards/light-translucent/HAI_sticker_lightPlate14_S2.svg
+++ b/assets/scorecards/light-translucent/HAI_sticker_lightPlate14_S2.svg
@@ -22,11 +22,11 @@
   <g filter="url(#f-donut-2-800)">
     <g transform="rotate(-90 100 100)">
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="361.91 90.48"/>
-      <circle cx="100" cy="100" r="72" fill="none"
               stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="90.48 361.91" stroke-dashoffset="-361.91"/>
+              stroke-dasharray="90.48 361.91"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="361.91 90.48" stroke-dashoffset="-90.48"/>
     </g>
   </g>
 

--- a/assets/scorecards/light-translucent/HAI_sticker_lightPlate14_S3.svg
+++ b/assets/scorecards/light-translucent/HAI_sticker_lightPlate14_S3.svg
@@ -22,11 +22,11 @@
   <g filter="url(#f-donut-3-700)">
     <g transform="rotate(-90 100 100)">
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="316.67 135.72"/>
-      <circle cx="100" cy="100" r="72" fill="none"
               stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="135.72 316.67" stroke-dashoffset="-316.67"/>
+              stroke-dasharray="135.72 316.67"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="316.67 135.72" stroke-dashoffset="-135.72"/>
     </g>
   </g>
 

--- a/assets/scorecards/light-translucent/HAI_sticker_lightPlate14_S4.svg
+++ b/assets/scorecards/light-translucent/HAI_sticker_lightPlate14_S4.svg
@@ -22,11 +22,11 @@
   <g filter="url(#f-donut-4-600)">
     <g transform="rotate(-90 100 100)">
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="271.43 180.96"/>
-      <circle cx="100" cy="100" r="72" fill="none"
               stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="180.96 271.43" stroke-dashoffset="-271.43"/>
+              stroke-dasharray="180.96 271.43"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="271.43 180.96" stroke-dashoffset="-180.96"/>
     </g>
   </g>
 

--- a/assets/scorecards/light-translucent/HAI_sticker_lightPlate14_S5.svg
+++ b/assets/scorecards/light-translucent/HAI_sticker_lightPlate14_S5.svg
@@ -22,10 +22,10 @@
   <g filter="url(#f-donut-5-500)">
     <g transform="rotate(-90 100 100)">
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
               stroke-dasharray="226.19 226.19"/>
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
               stroke-dasharray="226.19 226.19" stroke-dashoffset="-226.19"/>
     </g>
   </g>

--- a/assets/scorecards/light-translucent/HAI_sticker_lightPlate14_S6.svg
+++ b/assets/scorecards/light-translucent/HAI_sticker_lightPlate14_S6.svg
@@ -22,11 +22,11 @@
   <g filter="url(#f-donut-6-300)">
     <g transform="rotate(-90 100 100)">
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="135.72 316.67"/>
-      <circle cx="100" cy="100" r="72" fill="none"
               stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="316.67 135.72" stroke-dashoffset="-135.72"/>
+              stroke-dasharray="316.67 135.72"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="135.72 316.67" stroke-dashoffset="-316.67"/>
     </g>
   </g>
 

--- a/assets/scorecards/light-translucent/HAI_sticker_lightPlate14_S7.svg
+++ b/assets/scorecards/light-translucent/HAI_sticker_lightPlate14_S7.svg
@@ -22,11 +22,11 @@
   <g filter="url(#f-donut-7-200)">
     <g transform="rotate(-90 100 100)">
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="90.48 361.91"/>
-      <circle cx="100" cy="100" r="72" fill="none"
               stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="361.91 90.48" stroke-dashoffset="-90.48"/>
+              stroke-dasharray="361.91 90.48"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="90.48 361.91" stroke-dashoffset="-361.91"/>
     </g>
   </g>
 

--- a/assets/scorecards/light-translucent/HAI_sticker_lightPlate14_S8.svg
+++ b/assets/scorecards/light-translucent/HAI_sticker_lightPlate14_S8.svg
@@ -22,11 +22,11 @@
   <g filter="url(#f-donut-8-100)">
     <g transform="rotate(-90 100 100)">
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="45.24 407.15"/>
-      <circle cx="100" cy="100" r="72" fill="none"
               stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="407.15 45.24" stroke-dashoffset="-45.24"/>
+              stroke-dasharray="407.15 45.24"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="45.24 407.15" stroke-dashoffset="-407.15"/>
     </g>
   </g>
 

--- a/assets/scorecards/light-translucent/HAI_sticker_lightPlate14_S9.svg
+++ b/assets/scorecards/light-translucent/HAI_sticker_lightPlate14_S9.svg
@@ -22,11 +22,11 @@
   <g filter="url(#f-donut-9-0)">
     <g transform="rotate(-90 100 100)">
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="0.00 452.39"/>
-      <circle cx="100" cy="100" r="72" fill="none"
               stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="452.39 0.00" stroke-dashoffset="-0.00"/>
+              stroke-dasharray="452.39 0.00"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="0.00 452.39" stroke-dashoffset="-452.39"/>
     </g>
   </g>
 

--- a/assets/scorecards/print-solid-dark/HAI_sticker_print_darkSolid_S0.svg
+++ b/assets/scorecards/print-solid-dark/HAI_sticker_print_darkSolid_S0.svg
@@ -7,11 +7,11 @@
   <g >
     <g transform="rotate(-90 100 100)">
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="452.39 0.00"/>
-      <circle cx="100" cy="100" r="72" fill="none"
               stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="0.00 452.39" stroke-dashoffset="-452.39"/>
+              stroke-dasharray="0.00 452.39"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="452.39 0.00" stroke-dashoffset="-0.00"/>
     </g>
   </g>
 

--- a/assets/scorecards/print-solid-dark/HAI_sticker_print_darkSolid_S1.svg
+++ b/assets/scorecards/print-solid-dark/HAI_sticker_print_darkSolid_S1.svg
@@ -7,11 +7,11 @@
   <g >
     <g transform="rotate(-90 100 100)">
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="429.77 22.62"/>
-      <circle cx="100" cy="100" r="72" fill="none"
               stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="22.62 429.77" stroke-dashoffset="-429.77"/>
+              stroke-dasharray="22.62 429.77"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="429.77 22.62" stroke-dashoffset="-22.62"/>
     </g>
   </g>
 

--- a/assets/scorecards/print-solid-dark/HAI_sticker_print_darkSolid_S2.svg
+++ b/assets/scorecards/print-solid-dark/HAI_sticker_print_darkSolid_S2.svg
@@ -7,11 +7,11 @@
   <g >
     <g transform="rotate(-90 100 100)">
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="361.91 90.48"/>
-      <circle cx="100" cy="100" r="72" fill="none"
               stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="90.48 361.91" stroke-dashoffset="-361.91"/>
+              stroke-dasharray="90.48 361.91"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="361.91 90.48" stroke-dashoffset="-90.48"/>
     </g>
   </g>
 

--- a/assets/scorecards/print-solid-dark/HAI_sticker_print_darkSolid_S3.svg
+++ b/assets/scorecards/print-solid-dark/HAI_sticker_print_darkSolid_S3.svg
@@ -7,11 +7,11 @@
   <g >
     <g transform="rotate(-90 100 100)">
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="316.67 135.72"/>
-      <circle cx="100" cy="100" r="72" fill="none"
               stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="135.72 316.67" stroke-dashoffset="-316.67"/>
+              stroke-dasharray="135.72 316.67"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="316.67 135.72" stroke-dashoffset="-135.72"/>
     </g>
   </g>
 

--- a/assets/scorecards/print-solid-dark/HAI_sticker_print_darkSolid_S4.svg
+++ b/assets/scorecards/print-solid-dark/HAI_sticker_print_darkSolid_S4.svg
@@ -7,11 +7,11 @@
   <g >
     <g transform="rotate(-90 100 100)">
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="271.43 180.96"/>
-      <circle cx="100" cy="100" r="72" fill="none"
               stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="180.96 271.43" stroke-dashoffset="-271.43"/>
+              stroke-dasharray="180.96 271.43"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="271.43 180.96" stroke-dashoffset="-180.96"/>
     </g>
   </g>
 

--- a/assets/scorecards/print-solid-dark/HAI_sticker_print_darkSolid_S5.svg
+++ b/assets/scorecards/print-solid-dark/HAI_sticker_print_darkSolid_S5.svg
@@ -7,10 +7,10 @@
   <g >
     <g transform="rotate(-90 100 100)">
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
               stroke-dasharray="226.19 226.19"/>
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
               stroke-dasharray="226.19 226.19" stroke-dashoffset="-226.19"/>
     </g>
   </g>

--- a/assets/scorecards/print-solid-dark/HAI_sticker_print_darkSolid_S6.svg
+++ b/assets/scorecards/print-solid-dark/HAI_sticker_print_darkSolid_S6.svg
@@ -7,11 +7,11 @@
   <g >
     <g transform="rotate(-90 100 100)">
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="135.72 316.67"/>
-      <circle cx="100" cy="100" r="72" fill="none"
               stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="316.67 135.72" stroke-dashoffset="-135.72"/>
+              stroke-dasharray="316.67 135.72"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="135.72 316.67" stroke-dashoffset="-316.67"/>
     </g>
   </g>
 

--- a/assets/scorecards/print-solid-dark/HAI_sticker_print_darkSolid_S7.svg
+++ b/assets/scorecards/print-solid-dark/HAI_sticker_print_darkSolid_S7.svg
@@ -7,11 +7,11 @@
   <g >
     <g transform="rotate(-90 100 100)">
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="90.48 361.91"/>
-      <circle cx="100" cy="100" r="72" fill="none"
               stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="361.91 90.48" stroke-dashoffset="-90.48"/>
+              stroke-dasharray="361.91 90.48"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="90.48 361.91" stroke-dashoffset="-361.91"/>
     </g>
   </g>
 

--- a/assets/scorecards/print-solid-dark/HAI_sticker_print_darkSolid_S8.svg
+++ b/assets/scorecards/print-solid-dark/HAI_sticker_print_darkSolid_S8.svg
@@ -7,11 +7,11 @@
   <g >
     <g transform="rotate(-90 100 100)">
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="45.24 407.15"/>
-      <circle cx="100" cy="100" r="72" fill="none"
               stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="407.15 45.24" stroke-dashoffset="-45.24"/>
+              stroke-dasharray="407.15 45.24"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="45.24 407.15" stroke-dashoffset="-407.15"/>
     </g>
   </g>
 

--- a/assets/scorecards/print-solid-dark/HAI_sticker_print_darkSolid_S9.svg
+++ b/assets/scorecards/print-solid-dark/HAI_sticker_print_darkSolid_S9.svg
@@ -7,11 +7,11 @@
   <g >
     <g transform="rotate(-90 100 100)">
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="0.00 452.39"/>
-      <circle cx="100" cy="100" r="72" fill="none"
               stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="452.39 0.00" stroke-dashoffset="-0.00"/>
+              stroke-dasharray="452.39 0.00"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="0.00 452.39" stroke-dashoffset="-452.39"/>
     </g>
   </g>
 

--- a/assets/scorecards/print-solid-light/HAI_sticker_print_lightSolid_S0.svg
+++ b/assets/scorecards/print-solid-light/HAI_sticker_print_lightSolid_S0.svg
@@ -7,11 +7,11 @@
   <g >
     <g transform="rotate(-90 100 100)">
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="452.39 0.00"/>
-      <circle cx="100" cy="100" r="72" fill="none"
               stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="0.00 452.39" stroke-dashoffset="-452.39"/>
+              stroke-dasharray="0.00 452.39"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="452.39 0.00" stroke-dashoffset="-0.00"/>
     </g>
   </g>
 

--- a/assets/scorecards/print-solid-light/HAI_sticker_print_lightSolid_S1.svg
+++ b/assets/scorecards/print-solid-light/HAI_sticker_print_lightSolid_S1.svg
@@ -7,11 +7,11 @@
   <g >
     <g transform="rotate(-90 100 100)">
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="429.77 22.62"/>
-      <circle cx="100" cy="100" r="72" fill="none"
               stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="22.62 429.77" stroke-dashoffset="-429.77"/>
+              stroke-dasharray="22.62 429.77"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="429.77 22.62" stroke-dashoffset="-22.62"/>
     </g>
   </g>
 

--- a/assets/scorecards/print-solid-light/HAI_sticker_print_lightSolid_S2.svg
+++ b/assets/scorecards/print-solid-light/HAI_sticker_print_lightSolid_S2.svg
@@ -7,11 +7,11 @@
   <g >
     <g transform="rotate(-90 100 100)">
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="361.91 90.48"/>
-      <circle cx="100" cy="100" r="72" fill="none"
               stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="90.48 361.91" stroke-dashoffset="-361.91"/>
+              stroke-dasharray="90.48 361.91"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="361.91 90.48" stroke-dashoffset="-90.48"/>
     </g>
   </g>
 

--- a/assets/scorecards/print-solid-light/HAI_sticker_print_lightSolid_S3.svg
+++ b/assets/scorecards/print-solid-light/HAI_sticker_print_lightSolid_S3.svg
@@ -7,11 +7,11 @@
   <g >
     <g transform="rotate(-90 100 100)">
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="316.67 135.72"/>
-      <circle cx="100" cy="100" r="72" fill="none"
               stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="135.72 316.67" stroke-dashoffset="-316.67"/>
+              stroke-dasharray="135.72 316.67"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="316.67 135.72" stroke-dashoffset="-135.72"/>
     </g>
   </g>
 

--- a/assets/scorecards/print-solid-light/HAI_sticker_print_lightSolid_S4.svg
+++ b/assets/scorecards/print-solid-light/HAI_sticker_print_lightSolid_S4.svg
@@ -7,11 +7,11 @@
   <g >
     <g transform="rotate(-90 100 100)">
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="271.43 180.96"/>
-      <circle cx="100" cy="100" r="72" fill="none"
               stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="180.96 271.43" stroke-dashoffset="-271.43"/>
+              stroke-dasharray="180.96 271.43"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="271.43 180.96" stroke-dashoffset="-180.96"/>
     </g>
   </g>
 

--- a/assets/scorecards/print-solid-light/HAI_sticker_print_lightSolid_S5.svg
+++ b/assets/scorecards/print-solid-light/HAI_sticker_print_lightSolid_S5.svg
@@ -7,10 +7,10 @@
   <g >
     <g transform="rotate(-90 100 100)">
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
               stroke-dasharray="226.19 226.19"/>
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
               stroke-dasharray="226.19 226.19" stroke-dashoffset="-226.19"/>
     </g>
   </g>

--- a/assets/scorecards/print-solid-light/HAI_sticker_print_lightSolid_S6.svg
+++ b/assets/scorecards/print-solid-light/HAI_sticker_print_lightSolid_S6.svg
@@ -7,11 +7,11 @@
   <g >
     <g transform="rotate(-90 100 100)">
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="135.72 316.67"/>
-      <circle cx="100" cy="100" r="72" fill="none"
               stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="316.67 135.72" stroke-dashoffset="-135.72"/>
+              stroke-dasharray="316.67 135.72"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="135.72 316.67" stroke-dashoffset="-316.67"/>
     </g>
   </g>
 

--- a/assets/scorecards/print-solid-light/HAI_sticker_print_lightSolid_S7.svg
+++ b/assets/scorecards/print-solid-light/HAI_sticker_print_lightSolid_S7.svg
@@ -7,11 +7,11 @@
   <g >
     <g transform="rotate(-90 100 100)">
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="90.48 361.91"/>
-      <circle cx="100" cy="100" r="72" fill="none"
               stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="361.91 90.48" stroke-dashoffset="-90.48"/>
+              stroke-dasharray="361.91 90.48"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="90.48 361.91" stroke-dashoffset="-361.91"/>
     </g>
   </g>
 

--- a/assets/scorecards/print-solid-light/HAI_sticker_print_lightSolid_S8.svg
+++ b/assets/scorecards/print-solid-light/HAI_sticker_print_lightSolid_S8.svg
@@ -7,11 +7,11 @@
   <g >
     <g transform="rotate(-90 100 100)">
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="45.24 407.15"/>
-      <circle cx="100" cy="100" r="72" fill="none"
               stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="407.15 45.24" stroke-dashoffset="-45.24"/>
+              stroke-dasharray="407.15 45.24"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="45.24 407.15" stroke-dashoffset="-407.15"/>
     </g>
   </g>
 

--- a/assets/scorecards/print-solid-light/HAI_sticker_print_lightSolid_S9.svg
+++ b/assets/scorecards/print-solid-light/HAI_sticker_print_lightSolid_S9.svg
@@ -7,11 +7,11 @@
   <g >
     <g transform="rotate(-90 100 100)">
       <circle cx="100" cy="100" r="72" fill="none"
-              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="0.00 452.39"/>
-      <circle cx="100" cy="100" r="72" fill="none"
               stroke="#0B2545" stroke-width="42" stroke-linecap="butt"
-              stroke-dasharray="452.39 0.00" stroke-dashoffset="-0.00"/>
+              stroke-dasharray="452.39 0.00"/>
+      <circle cx="100" cy="100" r="72" fill="none"
+              stroke="#FFC300" stroke-width="42" stroke-linecap="butt"
+              stroke-dasharray="0.00 452.39" stroke-dashoffset="-452.39"/>
     </g>
   </g>
 

--- a/scripts/generate_hai_scorecards.py
+++ b/scripts/generate_hai_scorecards.py
@@ -59,11 +59,11 @@ def svg_for(score, p, plate_fill, plate_opacity, text_color, with_filters):
   <g {donut_filter_attr}>
     <g transform="rotate(-90 100 100)">
       <circle cx="100" cy="100" r="{RADIUS}" fill="none"
-              stroke="{HUMAN}" stroke-width="{RING_WIDTH}" stroke-linecap="butt"
-              stroke-dasharray="{Hs} {As}"/>
-      <circle cx="100" cy="100" r="{RADIUS}" fill="none"
               stroke="{AI}" stroke-width="{RING_WIDTH}" stroke-linecap="butt"
-              stroke-dasharray="{As} {Hs}" stroke-dashoffset="-{Hs}"/>
+              stroke-dasharray="{As} {Hs}"/>
+      <circle cx="100" cy="100" r="{RADIUS}" fill="none"
+              stroke="{HUMAN}" stroke-width="{RING_WIDTH}" stroke-linecap="butt"
+              stroke-dasharray="{Hs} {As}" stroke-dashoffset="-{As}"/>
     </g>
   </g>
 


### PR DESCRIPTION
## Summary
- draw the AI arc first and offset the human arc in `generate_hai_scorecards`
- regenerate all scorecard SVGs so the navi-colored arc appears on the right

## Testing
- `make generate-scorecards`


------
https://chatgpt.com/codex/tasks/task_e_688696a5ab288325980d0e314c0c8fc2